### PR TITLE
Fix Dalamud log path

### DIFF
--- a/Dalamud.Updater/Dalamud/DalamudStartInfo.cs
+++ b/Dalamud.Updater/Dalamud/DalamudStartInfo.cs
@@ -19,5 +19,7 @@ namespace XIVLauncher.Common.Dalamud
         public bool OptOutMbCollection;
 
         public bool GlobalAccelerate;
+
+        public string LogDirectory;
     }
 }

--- a/Dalamud.Updater/Dalamud/WindowsDalamudRunner.cs
+++ b/Dalamud.Updater/Dalamud/WindowsDalamudRunner.cs
@@ -26,7 +26,8 @@ public static class WindowsDalamudRunner
             $"--dalamud-dev-plugin-directory=\"{startInfo.DefaultPluginDirectory}\"",
             $"--dalamud-asset-directory=\"{startInfo.AssetDirectory}\"",
             $"--dalamud-client-language={startInfo.Language}",
-            $"--dalamud-delay-initialize={startInfo.DelayInitializeMs}"
+            $"--dalamud-delay-initialize={startInfo.DelayInitializeMs}",
+            $"--logpath={startInfo.LogDirectory}",
         };
 
         if (safeMode) launchArguments.Add("--no-plugin");

--- a/Dalamud.Updater/FormMain.cs
+++ b/Dalamud.Updater/FormMain.cs
@@ -503,10 +503,11 @@ namespace Dalamud.Updater
                 RuntimeDirectory = runtimeDirectory.FullName,
                 AssetDirectory = this.dalamudUpdater.AssetDirectory.FullName,
                 GameVersion = gameVerStr,
-                Language = "4",
+                Language = "korean",
                 OptOutMbCollection = false,
                 WorkingDirectory = dalamudPath,
-                DelayInitializeMs = injectDelay
+                DelayInitializeMs = injectDelay,
+                LogDirectory = xivlauncherDir,
             };
 
             return startInfo;


### PR DESCRIPTION
현재 달라가브의 기본 로그가 `%APPDATA%\XIVLauncher\addon\{VERSION}` 하위에 생성되도록 되어있습니다.
하지만 실제 달라가브의 설치 경로는 updater가 있는 폴더의 `XIVLauncher\addon\{VERSION}` 에 위치해 있어 실제 로그의 위치가 달라 디버깅이나 오류 제보를 받을 때 로그 전달의 어려움이 있습니다.

로그 경로를 직접 지정해주어 XIVLauncher 하위에 생성되도록 합니다.